### PR TITLE
Add timeout to InfluxDBClient

### DIFF
--- a/src/main/python/zcan/influxdb_writer.py
+++ b/src/main/python/zcan/influxdb_writer.py
@@ -5,11 +5,11 @@ from zcan.util import get_logger, get_current_time
 
 
 class InfluxDbWriter(object):
-    def __init__(self, host="influxdb", port=8086, user="root", password="root", db="zcan"):
+    def __init__(self, host="influxdb", port=8086, user="root", password="root", db="zcan", timeout=1, retries=2):
         self.logger = get_logger("InfluxDbWriter")
         self.db = db
 
-        self.client = InfluxDBClient(host, port, user, password, db)
+        self.client = InfluxDBClient(host, port, user, password, db, timeout=timeout, retries=retries)
         self.client.create_database(db)
 
     def send_metric_datapoint(self, measurement: Measurement):


### PR DESCRIPTION
To avoid InfluxDBClient from hanging (likely due to sub-optimal wifi connection to non-local InfluxDB server), add parameters for timeout (1s) and for conducting one retry (retries=2).